### PR TITLE
add support for chef code in subdirectory

### DIFF
--- a/cmd/chef-deploy.go
+++ b/cmd/chef-deploy.go
@@ -22,6 +22,7 @@ var (
   --from=<from>                 base SHA of the diff to deploy
   --to=<to>                     head SHA of the diff to deploy
   --knife-executable=<knife>    the knife executable to use
+  --subdirectory=<subdirectory> the subdirectory of the repo that contains chef code
   -h --help                     Show this screen.
   --version                     Show version.
 `

--- a/pkg/chef/chef_test.go
+++ b/pkg/chef/chef_test.go
@@ -69,11 +69,76 @@ func TestDeployChanges(t *testing.T) {
 
 }
 
+func TestDeployChangesWithSubdirectory(t *testing.T) {
+	git.CommandRunner = fakeGitRunner{}
+	RanCommands = make([]string, 0, 10)
+	CommandRunner = fakeTestRunner
+
+	Subdirectory = "chef"
+
+	DeployChanges("HEAD~5", "HEAD")
+
+	sort.Strings(RanCommands)
+
+	assert.Equal(t, len(RanCommands), 11)
+	expectedRanCommands := []string{
+		"knife cookbook -ay delete deleted",
+		"knife cookbook upload chef-deploy",
+		"knife cookbook upload homedirs",
+		"knife cookbook upload jenkins",
+		"knife cookbook upload nginx",
+		"knife data bag -y delete chef-keys bla",
+		"knife data bag -y delete chef-keys blubb",
+		"knife data bag from file chef-keys data_bags/chef-keys/friday.json",
+		"knife data bag from file chef-keys data_bags/chef-keys/friday_keys.json",
+		"knife role -y delete jail",
+		"knife role from file roles/ci.rb",
+	}
+
+	for i := range RanCommands {
+		assert.Equal(t, expectedRanCommands[i], RanCommands[i])
+	}
+
+}
+
+func TestDeployChangesWithSubdirectoryWithSlash(t *testing.T) {
+	git.CommandRunner = fakeGitRunner{}
+	RanCommands = make([]string, 0, 10)
+	CommandRunner = fakeTestRunner
+
+	Subdirectory = "chef/"
+
+	DeployChanges("HEAD~5", "HEAD")
+
+	sort.Strings(RanCommands)
+
+	assert.Equal(t, len(RanCommands), 11)
+	expectedRanCommands := []string{
+		"knife cookbook -ay delete deleted",
+		"knife cookbook upload chef-deploy",
+		"knife cookbook upload homedirs",
+		"knife cookbook upload jenkins",
+		"knife cookbook upload nginx",
+		"knife data bag -y delete chef-keys bla",
+		"knife data bag -y delete chef-keys blubb",
+		"knife data bag from file chef-keys data_bags/chef-keys/friday.json",
+		"knife data bag from file chef-keys data_bags/chef-keys/friday_keys.json",
+		"knife role -y delete jail",
+		"knife role from file roles/ci.rb",
+	}
+
+	for i := range RanCommands {
+		assert.Equal(t, expectedRanCommands[i], RanCommands[i])
+	}
+
+}
+
 func TestDeployChangesWithDifferentKnifeExecutable(t *testing.T) {
 	git.CommandRunner = fakeGitRunner{}
 	RanCommands = make([]string, 0, 10)
 	CommandRunner = fakeTestRunner
 
+	Subdirectory = ""
 	KnifeExecutable = "/opt/chef/bin/knife"
 
 	DeployChanges("HEAD~5", "HEAD")


### PR DESCRIPTION
when chef code is contained in a subdirectory it might be nice to have an option to strip that subdirectory prefix from the git path when generating the commands